### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -144,8 +144,8 @@ mod tests {
             ("  image: nginx", Ok(("  image: ", "nginx"))),
             ("  image: library/nginx", Ok(("  image: ", "library/nginx"))),
             (
-                "  image: gchr.io/library/nginx",
-                Ok(("  image: ", "gchr.io/library/nginx")),
+                "  image: ghcr.io/library/nginx",
+                Ok(("  image: ", "ghcr.io/library/nginx")),
             ),
             ("  image: nginx # comment", Ok(("  image: ", "nginx"))),
             ("  image: test-hyphen", Ok(("  image: ", "test-hyphen"))),


### PR DESCRIPTION
Hi `eppixx/reel-moby`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used - In some cases it's only a matter of wrongly tagged container images)
Please verify the changes made with this PR and check your documentation for similar typos.